### PR TITLE
DB + Routers: Track list/upsert, tRPC ctx db, adminProcedure, seed update

### DIFF
--- a/apps/web/src/server/routers/_app.ts
+++ b/apps/web/src/server/routers/_app.ts
@@ -1,8 +1,10 @@
 import { createTRPCRouter } from '@/server/trpc';
 import { lessonRouter } from './lesson';
+import { trackRouter } from './track';
 
 export const appRouter = createTRPCRouter({
   lesson: lessonRouter,
+  track: trackRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/src/server/routers/track.ts
+++ b/apps/web/src/server/routers/track.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { createTRPCRouter, publicProcedure, adminProcedure } from '@/server/trpc';
+
+export const trackRouter = createTRPCRouter({
+  list: publicProcedure
+    .input(z.object({ page: z.number().min(1).default(1), pageSize: z.number().min(1).max(100).default(10) }).optional())
+    .query(async ({ ctx, input }) => {
+      const page = input?.page ?? 1;
+      const pageSize = input?.pageSize ?? 10;
+      const [items, total] = await Promise.all([
+        ctx.db.track.findMany({ orderBy: { order: 'asc' }, skip: (page - 1) * pageSize, take: pageSize }),
+        ctx.db.track.count(),
+      ]);
+      return { items, total, page, pageSize };
+    }),
+
+  upsert: adminProcedure
+    .input(z.object({ id: z.string().optional(), slug: z.string().min(1), name: z.string().min(1), phase: z.enum(['FOUNDATION','AI_AUGMENTED','INTEGRATION','ADVANCED']), order: z.number().int().min(0).default(0) }))
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      const result = await ctx.db.track.upsert({
+        where: id ? { id } : { slug: input.slug },
+        create: data,
+        update: data,
+      });
+      return result;
+    }),
+});
+
+

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -1,14 +1,16 @@
 import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
 import { getSession } from './auth';
+import { db as prisma } from './db';
 
 export type TRPCContext = {
   session: Awaited<ReturnType<typeof getSession>>;
+  db: typeof prisma;
 };
 
 export async function createTRPCContext(): Promise<TRPCContext> {
   const session = await getSession();
-  return { session };
+  return { session, db: prisma };
 }
 
 const t = initTRPC.context<TRPCContext>().create({
@@ -20,6 +22,14 @@ export const publicProcedure = t.procedure;
 export const protectedProcedure = t.procedure.use(async ({ ctx, next }) => {
   if (!ctx.session?.user) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
+  }
+  return next();
+});
+
+export const adminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  const role = (ctx.session?.user as any)?.role as string | undefined;
+  if (role !== 'ADMIN' && role !== 'STAFF') {
+    throw new TRPCError({ code: 'FORBIDDEN' });
   }
   return next();
 });

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,0 +1,9 @@
+To create migrations locally, set `DATABASE_URL` to a running PostgreSQL instance, e.g.:
+
+```
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres?schema=public"
+pnpm dlx prisma migrate dev --name init --schema prisma/schema.prisma
+```
+
+For CI, use `prisma generate` for types, and run `prisma migrate deploy` during deployment.
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -19,6 +19,12 @@ async function main() {
     },
     update: {},
   });
+
+  await db.track.upsert({
+    where: { slug: 'ai-augmented' },
+    create: { slug: 'ai-augmented', name: 'AI‑Augmented Testing', phase: TrackPhase.AI_AUGMENTED, order: 2 },
+    update: {},
+  });
 }
 
 main()


### PR DESCRIPTION
Scope\n- Part of Step 4 in README: add Prisma-backed routers and seeds.\n\nDetails\n- Expose Prisma client on tRPC ctx ()\n- Add  for RBAC\n- Track router: , \n- Seed: Foundation + AI‑Augmented tracks, Git Basics module\n- Prisma migration docs in  (migrate locally only)\n\nNon-goals\n- Applying migrations in CI (deploy will handle)\n- Other routers (module/lesson/quiz/lab)\n\nHow to run\n- pnpm --filter web dev; call  via tRPC client or curl to  accordingly\n\nAcceptance\n-  returns seeded tracks\n-  restricted to ADMIN/STAFF via RBAC\n- Typecheck/build/tests pass in CI\n\nReadme is the spec; this PR maps to Step 4 (partial).